### PR TITLE
Add step by step instructions on finding your device's info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # webvr-polyfill-dpdb
 
-This is a fork of the [online cache](https://storage.googleapis.com/cardboard-dpdb/dpdb.json) of the Device Parameter Database (DPDB) for the [WebVR Polyfill](https://github.com/googlevr/webvr-polyfill).
+This is a fork of the [online cache](https://storage.googleapis.com/cardboard-dpdb/dpdb.json) of the Device Parameter Database (DPDB) for the [webvr-polyfill].
+
+## Adding A Device
+
+You'll need to update `dpdb-formatted.json` with your device's information in the following format:
+
+```json
+{
+  "type": "android",
+  "rules": [
+    {
+      "mdmh": "asus/*/ASUS_Z00AD/*"
+    },
+    {
+      "ua": "ASUS_Z00AD"
+    }
+    ],
+  "dpi": [
+    403,
+    404.6
+  ],
+  "bw": 3,
+  "ac": 1000
+}
+```
+
+* `type`: Either `"android"` or `"ios"`.
+* `rules`: An array of various rules that must be satisfied in order to use the configuration. Each rule is an object with one property and can be one of the following:
+    * `ua`: The User-Agent string to match. Go to [useragentstring.com] and find something unique that looks like the device's name. Use this if type is `"android"`.
+    * `res`: An array of resolution values as width and height. Use this if type is `"ios"`.
+    * `mdmh`: The make and model of the device. Currently unused in [webvr-polyfill], and used for native devices(?) -- see other entries.
+* `dpi`: An array of the DPI values of the screen as `[x, y]` values. Get this information via the [Device Info App] and look for `Actual DPI X` and `Actual DPI Y` values.
+* `ac`: Currently unused in [webvr-polyfill]?
+* `bw`: The bezel width in millimeters. 3 and 4 are common bezel widths, but you can calculate the exact width using this formula, where `deviceWidth` is in millimeters, `screen` is the screen's diagonal length in millimeters, and `ratio` is the screen resolution's `width / height`:
+
+```js
+(deviceWidth - Math.sqrt((screen * screen) / (1 + (1 / (ratio * ratio))))) / 2;
+```
+
+## Change Log
 
 The following devices were added (and/or corrections made):
 
@@ -17,3 +56,7 @@ The following devices were added (and/or corrections made):
 - [Samsung Galaxy S7 Edge](https://github.com/googlevr/webvr-polyfill/issues/164#issuecomment-266108204)
 - [iPhone 6S+](https://github.com/borismus/webvr-boilerplate/issues/146#issuecomment-253711181)
 - Removed double entries for several iOS settings
+
+[webvr-polyfill]: https://github.com/googlevr/webvr-polyfill
+[useragentstring.com]: http://useragentstring.com/
+[Device Info App]: https://play.google.com/store/apps/details?id=com.jphilli85.deviceinfo


### PR DESCRIPTION
I think this will clear up a lot of issues in webvr-polyfill of people wanting to add their own devices to dpdb, as well as reference for those wanting to add locally.

A sanity check on the bezel width math would be appreciated as well!